### PR TITLE
Remove type checking from Star getattr

### DIFF
--- a/starcat/starcatalog.py
+++ b/starcat/starcatalog.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import inspect
 import numpy as np
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator, Optional, no_type_check
 
 
 AS_TO_DEG = 1 / 3600.
@@ -302,6 +302,13 @@ class Star:
         ret += f' | SCLASS {self.spectral_class:s}'
 
         return ret
+
+    # This is a stupid thing to do, but it's necessary to avoid mypy from complaining
+    # about missing attributes. mypy ignores attributes for classes that have a
+    # __getattr__ method.
+    @no_type_check
+    def __getattr__(self, name: str) -> Any:
+        return super().__getattr__(name)
 
     def to_dict(self) -> dict[str, Any]:
         """Return a dictionary containing all star attributes."""

--- a/starcat/starcatalog.py
+++ b/starcat/starcatalog.py
@@ -2,6 +2,8 @@
 # starcat/starcatalog.py
 ################################################################################
 
+from future import annotations
+
 from collections.abc import Iterator
 import inspect
 import numpy as np

--- a/starcat/starcatalog.py
+++ b/starcat/starcatalog.py
@@ -2,7 +2,7 @@
 # starcat/starcatalog.py
 ################################################################################
 
-from future import annotations
+from __future__ import annotations
 
 from collections.abc import Iterator
 import inspect

--- a/starcat/starcatalog.py
+++ b/starcat/starcatalog.py
@@ -2,11 +2,10 @@
 # starcat/starcatalog.py
 ################################################################################
 
-from __future__ import annotations
-
+from collections.abc import Iterator
 import inspect
 import numpy as np
-from typing import Any, Iterator, Optional, no_type_check
+from typing import Any, Optional, no_type_check
 
 
 AS_TO_DEG = 1 / 3600.
@@ -308,7 +307,7 @@ class Star:
     # __getattr__ method.
     @no_type_check
     def __getattr__(self, name: str) -> Any:
-        return super().__getattr__(name)
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     def to_dict(self) -> dict[str, Any]:
         """Return a dictionary containing all star attributes."""


### PR DESCRIPTION
Right now if you add a new attribute to `Star`, `mypy` will complain that the new attribute is not valid because it's not actually defined by the `Star` class. But we want to be able to do this. This PR disables type checking from `Star.__getattr__`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved attribute-access handling for the Star entity to suppress static type-checker errors while preserving runtime behavior, improving type-safety and reducing false-positive warnings during development. This change is internal and does not alter user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->